### PR TITLE
Solution proposal [not solved but temporarily present a solution]

### DIFF
--- a/lib/YoloVideo.dart
+++ b/lib/YoloVideo.dart
@@ -60,6 +60,9 @@ class _YoloVideoState extends State<YoloVideo> {
           isDetecting = false;
           yoloResults = [];
         });
+
+        // TODO: make dynamic orientation lock, in case the user wants to landscape right
+        controller.lockCaptureOrientation(DeviceOrientation.landscapeLeft);
       });
     });
 

--- a/lib/YoloVideo.dart
+++ b/lib/YoloVideo.dart
@@ -121,10 +121,13 @@ class _YoloVideoState extends State<YoloVideo> {
     return Stack(
       fit: StackFit.expand,
       children: [
-        AspectRatio(
-          aspectRatio: controller.value.aspectRatio,
-          child: CameraPreview(
-            controller,
+        RotatedBox(
+          quarterTurns: 1, // rotate the display 90 degrees clockwise
+          child: AspectRatio(
+            aspectRatio: controller.value.aspectRatio,
+            child: CameraPreview(
+              controller,
+            ),
           ),
         ),
         ...displayBoxesAroundRecognizedObjects(size),

--- a/lib/YoloVideo.dart
+++ b/lib/YoloVideo.dart
@@ -5,6 +5,7 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/placeholder.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_vision/flutter_vision.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,11 +38,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   @override
-  void dispose() {
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: task(option),


### PR DESCRIPTION
- displaying bounding boxes needs to be relative to the image (not implemented)
- It is almost as impossible to rotate the CameraImage object, so rotating it before executing detection is difficult. So, retrain the model with the dataset with orientation in mind.
- Item 2 can be avoided if you have implemented the item 1. so that you can safely rotate the display image and bounding boxes.